### PR TITLE
Added constructor that accepts a DB object, to facilitate mocking.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>be.datablend</groupId>
     <artifactId>blueprints-mongodb-graph</artifactId>
-    <version>0.1</version>
+    <version>0.4.0-SNAPSHOT</version>
     <description>Blueprints property graph implementation on top of the MongoDB database</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blueprints.version>2.3.0</blueprints.version>
-        <rexster.version>2.3.0</rexster.version>
+        <blueprints.version>2.4.0-SNAPSHOT</blueprints.version>
+        <rexster.version>2.4.0-SNAPSHOT</rexster.version>
         <mongodb-java-driver.version>2.9.1</mongodb-java-driver.version>
     </properties>
 
@@ -58,6 +58,11 @@
             <groupId>com.tinkerpop.rexster</groupId>
             <artifactId>rexster-core</artifactId>
             <version>${rexster.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.foursquare</groupId>
+            <artifactId>fongo</artifactId>
+            <version>1.1.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/be/datablend/blueprints/impls/mongodb/MongoDBGraph.java
+++ b/src/main/java/be/datablend/blueprints/impls/mongodb/MongoDBGraph.java
@@ -77,7 +77,6 @@ public class MongoDBGraph implements MetaGraph<DB>, KeyIndexableGraph {
         FEATURES.supportsDuplicateEdges = true;
         FEATURES.supportsSelfLoops = true;
         FEATURES.isPersistent = true;
-        FEATURES.isRDFModel = false;
         FEATURES.supportsVertexIteration = true;
         FEATURES.supportsEdgeIteration = true;
         FEATURES.supportsVertexIndex = false;
@@ -153,6 +152,9 @@ public class MongoDBGraph implements MetaGraph<DB>, KeyIndexableGraph {
 
     @Override
     public Edge addEdge(final Object id, final Vertex outVertex, final Vertex inVertex, final String label) {
+        if (label == null) {
+            throw new IllegalArgumentException("Cannot set null edge label");
+        }
         final MongoDBEdge edge = new MongoDBEdge(this);
         edgeCollection.insert(new BasicDBObject().append(MONGODB_ID, edge.getId())
                 .append(IN_VERTEX_PROPERTY, inVertex.getId())

--- a/src/test/java/be/datablend/blueprints/impls/mongodb/MongoDBGraphTest.java
+++ b/src/test/java/be/datablend/blueprints/impls/mongodb/MongoDBGraphTest.java
@@ -1,6 +1,9 @@
 package be.datablend.blueprints.impls.mongodb;
 
+import com.foursquare.fongo.Fongo;
+import com.mongodb.DB;
 import com.tinkerpop.blueprints.*;
+import static com.tinkerpop.blueprints.BaseTest.printTestPerformance;
 import com.tinkerpop.blueprints.impls.GraphTest;
 import com.tinkerpop.blueprints.util.io.gml.GMLReaderTestSuite;
 import com.tinkerpop.blueprints.util.io.graphml.GraphMLReaderTestSuite;
@@ -41,9 +44,15 @@ public class MongoDBGraphTest extends GraphTest {
         printTestPerformance("GraphTestSuite", this.stopWatch());
     }
 
-    public void testQueryTestSuite() throws Exception {
+    public void testGraphQueryTestSuite() throws Exception {
         this.stopWatch();
-        doTestSuite(new QueryTestSuite(this));
+        doTestSuite(new GraphQueryTestSuite(this));
+        printTestPerformance("QueryTestSuite", this.stopWatch());
+    }
+    
+    public void testVertexQueryTestSuite() throws Exception {
+        this.stopWatch();
+        doTestSuite(new VertexQueryTestSuite(this));
         printTestPerformance("QueryTestSuite", this.stopWatch());
     }
 
@@ -75,6 +84,8 @@ public class MongoDBGraphTest extends GraphTest {
     @Override
     public Graph generateGraph() {
         this.currentGraph = new MongoDBGraph("localhost", 27017);
+//        DB db = new Fongo("test").getDB("graph");
+//        this.currentGraph = new MongoDBGraph(db);
         return this.currentGraph;
     }
 


### PR DESCRIPTION
Just overloaded the MongoDBGraph constructor to support passing in a database object, which can be provided by any number of replacement databases (read: Fongo) to facilitate easier testing. It should be 100% compatible with existing changes, and makes development easier.
